### PR TITLE
Add new error messages and rescuing

### DIFF
--- a/lib/openvas.rb
+++ b/lib/openvas.rb
@@ -13,11 +13,17 @@ require 'openvas/result'
 module Openvas
   extend self
 
+  class OpenvasError < StandardError; end
+  class AuthError < OpenvasError; end
+  class ConnectionError < OpenvasError; end
+  class ConfigError < OpenvasError; end
+  class QueryError < OpenvasError; end
+
   def configure
     block_given? ? yield(Config) : Config
     %w[url username password].each do |key|
       next unless Openvas::Config.instance_variable_get("@#{key}").nil?
-      raise Openvas::Config::RequiredOptionMissing,
+      raise ConfigError,
             "Configuration parameter missing: '#{key}'. " \
             'Please add it to the Openvas.configure block'
     end

--- a/lib/openvas/auth.rb
+++ b/lib/openvas/auth.rb
@@ -4,12 +4,10 @@ require 'nokogiri'
 
 module Openvas
   class Auth < Client
-    class InvalidLogin < StandardError; end
-
     # Do Login
     def self.login
-      raise InvalidLogin, 'Please configure the username' unless Openvas::Config.username
-      raise InvalidLogin, 'Please configure the password' unless Openvas::Config.password
+      raise ConfigError, 'Username not configured' unless Openvas::Config.username
+      raise ConfigError, 'Password not configured' unless Openvas::Config.password
 
       content = Nokogiri::XML::Builder.new do |xml|
         xml.authenticate do
@@ -20,7 +18,11 @@ module Openvas
         end
       end
 
-      query(content)
+      begin
+        query(content)
+      rescue QueryError
+        raise AuthError, 'Invalid login or password'
+      end
 
       true
     end

--- a/spec/openvas/auth_spec.rb
+++ b/spec/openvas/auth_spec.rb
@@ -20,12 +20,12 @@ describe Openvas::Auth do
 
     it 'without username' do
       Openvas::Config.username = nil
-      expect { Openvas::Auth.login }.to raise_exception(Openvas::Auth::InvalidLogin)
+      expect { Openvas::Auth.login }.to raise_exception(Openvas::ConfigError)
     end
 
     it 'without password' do
       Openvas::Config.password = nil
-      expect { Openvas::Auth.login }.to raise_exception(Openvas::Auth::InvalidLogin)
+      expect { Openvas::Auth.login }.to raise_exception(Openvas::ConfigError)
     end
   end
 end

--- a/spec/openvas/client_spec.rb
+++ b/spec/openvas/client_spec.rb
@@ -3,6 +3,20 @@
 require 'spec_helper'
 
 describe Openvas::Client do
+  describe '.connect' do
+    subject { Openvas::Client.connect }
+
+    context 'when failing' do
+      before do
+        allow(Openvas::Config).to receive(:url) { 'https://localhost:9390' }
+      end
+
+      it 'raises ConnectionError' do
+        expect { subject }.to raise_error Openvas::ConnectionError
+      end
+    end
+  end
+
   describe '#version' do
     before(:each) do
       allow(Openvas::Client).to receive(:query).and_return(fixture_xml('openvas/client/version.xml'))


### PR DESCRIPTION
Add new error messages and rescuing to better contextualize and understand errors when using the client.